### PR TITLE
feature/PublishPage

### DIFF
--- a/.github/workflows/publish-page.yaml
+++ b/.github/workflows/publish-page.yaml
@@ -1,0 +1,27 @@
+name: documentation
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: |
+          pip install sphinx sphinx_rtd_theme myst_parser
+      - name: Sphinx build
+        run: |
+          sphinx-build doc _build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true


### PR DESCRIPTION
Add publish-page.yaml

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a GitHub Actions workflow to build and deploy documentation to GitHub Pages on push events to the main branch.

CI:
- Add a new GitHub Actions workflow to automate the documentation build and deployment process.

<!-- Generated by sourcery-ai[bot]: end summary -->